### PR TITLE
Rename vertical to cloud, add failed execution check

### DIFF
--- a/csharp/ExecuteFunction.cs
+++ b/csharp/ExecuteFunction.cs
@@ -25,7 +25,7 @@ namespace PlayFab.AzureFunctions
     {
         private const string DEV_SECRET_KEY = "PLAYFAB_DEV_SECRET_KEY";
         private const string TITLE_ID = "PLAYFAB_TITLE_ID";
-        private const string VERTICAL_NAME = "PLAYFAB_VERTICAL_NAME";
+        private const string CLOUD_NAME = "PLAYFAB_CLOUD_NAME";
         private static readonly HttpClient httpClient = new HttpClient();
         /// <summary>
         /// A local implementation of the ExecuteFunction feature. Provides the ability to execute an Azure Function with a local URL with respect to the host
@@ -229,11 +229,11 @@ namespace PlayFab.AzureFunctions
             {
                 sb.Append(title).Append(".");
             }
-            // Append the vertical name if applicable
-            string vertical = Environment.GetEnvironmentVariable(VERTICAL_NAME, EnvironmentVariableTarget.Process);
-            if (!string.IsNullOrEmpty(vertical))
+            // Append the cloud name if applicable
+            string cloud = Environment.GetEnvironmentVariable(CLOUD_NAME, EnvironmentVariableTarget.Process);
+            if (!string.IsNullOrEmpty(cloud))
             {
-                sb.Append(vertical).Append(".");
+                sb.Append(cloud).Append(".");
             }
             // Append base PF API address
             sb.Append("playfabapi.com");


### PR DESCRIPTION
* All instances of vertical have been renamed to cloud
* We did not perform a check on the status code of the response from the azure function's execution. Which means that unless the target function threw, we would not be able to detect failure such as 404 where the function is just not found in the local run-time. Added a check for this.