### PR TITLE
Fix issue with default route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,18 @@ The above is supported in the following SDKs;
 * [PlayFab C# SDK](https://github.com/PlayFab/CSharpSDK)
 * [PlayFab Unity SDK](https://github.com/PlayFab/UnitySDK)
 * [Unreal 4 Marketplace PlugIn for PlayFab](https://github.com/PlayFab/UnrealMarketplacePlugin)
+
+## Custom route prefixes
+
+If you use a custom route prefix in your host.json, you will need to change the /api/ part of the file content to match the custom route prefix specified in the host.json. For example, if your host.json specifies a route prefix
+of 'cs', then your playfab.local.settings.json should be as follows;
+
+```
+{ "LocalApiServer": "http://localhost:7071/cs/" }
+```
+
+If your host.json specifies an empty custom route prefix, then your playfab.local.settings.jsoon should be as follows;
+
+```
+{ "LocalApiServer": "http://localhost:7071/" }
+```

--- a/csharp/ExecuteFunction.cs
+++ b/csharp/ExecuteFunction.cs
@@ -26,6 +26,7 @@ namespace PlayFab.AzureFunctions
         private const string DEV_SECRET_KEY = "PLAYFAB_DEV_SECRET_KEY";
         private const string TITLE_ID = "PLAYFAB_TITLE_ID";
         private const string CLOUD_NAME = "PLAYFAB_CLOUD_NAME";
+        private const string _defaultRoutePrefix = "api";
         private static readonly HttpClient httpClient = new HttpClient();
 
         /// <summary>
@@ -327,8 +328,7 @@ namespace PlayFab.AzureFunctions
             }
 
             var hostModel = PlayFabSimpleJson.DeserializeObject<HostJsonModel>(hostFileContent);
-
-            return hostModel?.extensions?.http?.routePrefix;
+            return hostModel?.extensions?.http?.routePrefix ?? _defaultRoutePrefix;
         }
 
         private static async Task<string> DecompressHttpBody(HttpRequest request)


### PR DESCRIPTION
If the Azure Functions app used the default route prefix of api, but
that route prefix was NOT specified in host.json, the GetHostRoutePrefix
method would return null. This would break local debugging as the
ExecuteFunction implementation would try to invoke the wrong URI for
the target function. For example, it would try to invoke /Test rather
than /api/Test.

This PR fixes this issue by having GetHostRoutePrefix return 'api' in
the case where no route prefix is specified in host.json.

This change has been tested with four cases;

1. Default route prefix, no prefix specified in host.json.
2. Default route prefix, prefix specified in host.json.
3. Custom, non-empty route prefix, prefix specified in host.json.
4. Custom, empty route prefix, prefix specified in host.json.

Also update readme.md to call out that custom route prefixes require
changes to playfab.local.settings.json.